### PR TITLE
Missions features

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,11 @@
 import { Route, Routes } from 'react-router-dom';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+
 import { getRockets } from './redux/rockets/rocketsSlice';
+import { getMissions } from './redux/missions/missionsSlice';
 import Navbar from './components/Navbar';
-import Missions from './components/Missions';
+import Missions from './components/Missions/Missions';
 import Rockets from './components/Rockets';
 import MyProfile from './components/MyProfile';
 
@@ -12,6 +14,7 @@ function App() {
 
   useEffect(() => {
     dispatch(getRockets());
+    dispatch(getMissions());
   }, [dispatch]);
 
   return (

--- a/src/components/Missions.jsx
+++ b/src/components/Missions.jsx
@@ -1,5 +1,0 @@
-const Missions = () => (
-  <div>Missions</div>
-);
-
-export default Missions;

--- a/src/components/Missions/Mission.jsx
+++ b/src/components/Missions/Mission.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+
+import { joinMission } from '../../redux/missions/missionsSlice';
+
+const Mission = ({
+  id, name, description, joined, index,
+}) => {
+  const dispatch = useDispatch();
+  return (
+    <>
+      <tr className={index % 2 === 0 ? 'bg-gray-100' : ''}>
+        <td className="p-3 border">{name}</td>
+        <td className="p-3 border">{description}</td>
+        <td className="p-3 border">{!joined ? 'NOT A MEMBER' : 'Active Member'}</td>
+        <td className="p-3 border">
+          <button
+            className={`py-1 rounded w-32 border ${!joined ? 'border-neutral-500 hover:bg-neutral-200 text-black' : 'border-red-500 hover:bg-red-300 text-red-500'} `}
+            type="button"
+            onClick={() => dispatch(joinMission(id))}
+          >
+            {!joined ? 'Join Mission' : 'Leave Mission'}
+          </button>
+        </td>
+      </tr>
+    </>
+  );
+};
+
+Mission.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  joined: PropTypes.bool.isRequired,
+  index: PropTypes.number.isRequired,
+};
+
+export default Mission;

--- a/src/components/Missions/Missions.jsx
+++ b/src/components/Missions/Missions.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import Mission from './Mission';
+
+const Missions = () => {
+  const { missions } = useSelector((store) => store.missions);
+
+  return (
+    <>
+      <section data-testid="Missions" className="container mx-auto py-5">
+        <table className="w-full border-collapse border">
+          <thead>
+            <tr className="h-10">
+              <th className="border text-left">Mission</th>
+              <th className="border text-left">Description</th>
+              <th className="border text-left">Status</th>
+              <th>&nbsp;</th>
+            </tr>
+          </thead>
+          <tbody>
+            {missions.map((mission, index) => (
+              <Mission
+                key={mission.mission_id}
+                id={mission.mission_id}
+                name={mission.mission_name}
+                description={mission.description}
+                joined={mission.joined}
+                index={index}
+              />
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </>
+  );
+};
+
+export default Missions;

--- a/src/components/Missions/MyMissions.jsx
+++ b/src/components/Missions/MyMissions.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+const MyMissions = () => {
+  const { missions } = useSelector((store) => store.missions);
+  const joinedMissions = missions.filter((mission) => mission.joined === true);
+  return (
+    <div>
+      <h2 className="font-semibold text-2xl mb-3">My Missions</h2>
+      <ul className="border-solid border-t-2 border-neutral-300">
+        {joinedMissions.length === 0 ? <li className="p-5 text-lg">No Missions yet</li>
+          : joinedMissions.map((mission) => <li className="border-solid border-2 border-t-0 border-neutral-300 p-5 text-lg" key={mission.mission_id}>{mission.mission_name}</li>)}
+      </ul>
+    </div>
+  );
+};
+
+export default MyMissions;

--- a/src/components/MyProfile.jsx
+++ b/src/components/MyProfile.jsx
@@ -1,8 +1,10 @@
 import MyRockets from './MyRockets';
+import MyMissions from './Missions/MyMissions';
 
 const MyProfile = () => (
-  <div className="px-20 py-5">
+  <div className="px-20 py-5 grid grid-cols-2 gap-4">
     <MyRockets />
+    <MyMissions />
   </div>
 );
 

--- a/src/components/MyRockets.jsx
+++ b/src/components/MyRockets.jsx
@@ -5,10 +5,11 @@ const MyRockets = () => {
   const reservedRockets = rocketsList.filter((rokt) => rokt.reserved === true);
 
   return (
-    <div className="w-1/2">
+    <div>
       <h2 className="font-semibold text-2xl mb-3">My Rockets</h2>
       <ul className="border-solid border-t-2 border-neutral-300">
-        {reservedRockets.map((rokt) => <li className="border-solid border-2 border-t-0 border-neutral-300 p-5 text-lg" key={rokt.id}>{rokt.name}</li>)}
+        {reservedRockets.length === 0 ? <li className="p-5 text-lg">No Rockets yet</li>
+          : reservedRockets.map((rokt) => <li className="border-solid border-2 border-t-0 border-neutral-300 p-5 text-lg" key={rokt.id}>{rokt.name}</li>)}
       </ul>
     </div>
   );

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,0 +1,33 @@
+import { createAsyncThunk, createReducer } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+export const getMissions = createAsyncThunk('missions/getMissions', async () => {
+  const response = await axios.get('https://api.spacexdata.com/v3/missions');
+  const { data } = await response;
+  return data;
+});
+
+const initialState = {
+  missions: [],
+  error: false,
+  isLoading: false,
+  message: null,
+};
+
+export default createReducer(initialState, (builder) => {
+  builder
+    .addCase(getMissions.pending, (state) => ({
+      ...state,
+      isLoading: true,
+    }))
+    .addCase(getMissions.fulfilled, (state, action) => ({
+      ...state,
+      isLoading: true,
+      missions: action.payload,
+    }))
+    .addCase(getMissions.rejected, (state, action) => ({
+      ...state,
+      isLoading: false,
+      error: action.error.message,
+    }));
+});

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,4 +1,4 @@
-import { createAsyncThunk, createReducer } from '@reduxjs/toolkit';
+import { createAction, createAsyncThunk, createReducer } from '@reduxjs/toolkit';
 import axios from 'axios';
 
 export const getMissions = createAsyncThunk('missions/getMissions', async () => {
@@ -7,11 +7,12 @@ export const getMissions = createAsyncThunk('missions/getMissions', async () => 
   return data;
 });
 
+export const joinMission = createAction('missions/joinMission');
+
 const initialState = {
   missions: [],
   error: false,
   isLoading: false,
-  message: null,
 };
 
 export default createReducer(initialState, (builder) => {
@@ -20,14 +21,23 @@ export default createReducer(initialState, (builder) => {
       ...state,
       isLoading: true,
     }))
-    .addCase(getMissions.fulfilled, (state, action) => ({
-      ...state,
-      isLoading: true,
-      missions: action.payload,
-    }))
+    .addCase(getMissions.fulfilled, (state, action) => {
+      action.payload.forEach((mission) => {
+        mission.joined = false;
+      });
+      return {
+        ...state,
+        isLoading: false,
+        missions: action.payload,
+      };
+    })
     .addCase(getMissions.rejected, (state, action) => ({
       ...state,
       isLoading: false,
       error: action.error.message,
-    }));
+    }))
+    .addCase(joinMission, (state, action) => {
+      const missionSel = state.missions.find((mission) => mission.mission_id === action.payload);
+      missionSel.joined = !missionSel.joined;
+    });
 });

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,10 +1,9 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import rocketsReducer from './rockets/rocketsSlice';
+import missionReducer from './missions/missionsSlice';
 
-const store = configureStore({
-  reducer: {
-    rockets: rocketsReducer,
-  },
-});
+const rootReducer = combineReducers({ rockets: rocketsReducer, missions: missionReducer });
+
+const store = configureStore({ reducer: rootReducer });
 
 export default store;


### PR DESCRIPTION
- Create directories for all Redux state slice file: missions
- Upon first render fetch data from the SpaceX API endpoints:
  - Missions: https://api.spacexdata.com/v3/missions
- Once the data are fetched, dispatch an action to store the selected data in Redux store:
  - Missions:
      - mission_id
      - mission_name
      - description
- Render a table with the missions' data (as per design).
- Create a reducer and action dispatcher for the "Join Mission" button. The logic here is practically the same as with rockets - you need to pass the mission's ID to the corresponding action and update the missions' state with the selected mission having a new key/value - reserved: true.
- Here you need to follow the same logic as with the "Reserve rocket"/"Reserve dragon" and "Join mission" - but you need to set the reserved key to false.
- Dispatch these actions upon click on the corresponding buttons.
- Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).